### PR TITLE
Beta 9

### DIFF
--- a/migrations/2016_02_13_000000_create_links_table.php
+++ b/migrations/2016_02_13_000000_create_links_table.php
@@ -9,7 +9,6 @@
  * file that was distributed with this source code.
  */
 
-use Flarum\Database\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Schema\Builder;
 


### PR DESCRIPTION
there wasn't even a need to fix index names, because the migration wasn't using any foreign key constraints :)