### PR TITLE
Fix comma syntax error in PHP 7.2.24

### DIFF
--- a/src/Command/CreateLinkHandler.php
+++ b/src/Command/CreateLinkHandler.php
@@ -48,7 +48,7 @@ class CreateLinkHandler
             Arr::get($data, 'attributes.url'),
             Arr::get($data, 'attributes.isInternal'),
             Arr::get($data, 'attributes.isNewtab'),
-            Arr::get($data, 'attributes.visibility'),
+            Arr::get($data, 'attributes.visibility')
         );
 
         $parentId = Arr::get($data, 'relationships.parent.data.id');


### PR DESCRIPTION
This bug happened earlier with another FoF extension (I don't remember which one exactly).

It seems that this specific PHP version (7.2) has a more strict comma-separator thing in arrays, functions and such.

In PHP 7.4, I assume that this is not a problem but on FreeFlarum we still use 7.2 and specifically the logs report an "Unexpected ')' at line 52" error.

That's because of the last comma after last function/array/key I don't know how PHP devs call it.

When that comma is removed, the extension then works normally and no longer reports the error. In other languages there isn't supposed to be a comma either because there's just nothing after it (so why put comma?), so it reports a syntax error, eg.: this is invalid in some other languages + PHP 7.2 apparently: 

```
{ 1, 2, 3, }
         ^ not supposed to be here
```

This fix should make it work with all PHP versions. I have no idea why PHP devs would change it to less strict after 7.2, but it just breaks so I made a PR.

**Edit:** It seems that this was "legalized" in PHP 7.3: https://php.watch/versions/7.3/func-call-trailing-comma (which means that we should probably just update PHP at FreeFlarum).