### PR TITLE
Add rel="noopener" to external _blank links

### DIFF
--- a/js/src/admin/components/EditLinkModal.js
+++ b/js/src/admin/components/EditLinkModal.js
@@ -132,16 +132,20 @@ export default class EditlinksModal extends Modal {
             40
         );
 
-        items.add('visibility', [
-            <div className="Form-group">
-                <label>{app.translator.trans('fof-links.admin.edit_link.visibility')}</label>
-                {Select.component({
-                    value: this.visibility(),
-                    onchange: this.visibility,
-                    options: this.typeOptions()
-                })}
-            </div>
-        ], 20);
+        items.add(
+            'visibility',
+            [
+                <div className="Form-group">
+                    <label>{app.translator.trans('fof-links.admin.edit_link.visibility')}</label>
+                    {Select.component({
+                        value: this.visibility(),
+                        onchange: this.visibility,
+                        options: this.typeOptions(),
+                    })}
+                </div>,
+            ],
+            20
+        );
 
         items.add(
             'actions',
@@ -174,7 +178,7 @@ export default class EditlinksModal extends Modal {
         let opts;
         opts = ['everyone', 'members', 'guests'].reduce((o, key) => {
             o[key] = app.translator.trans(`fof-links.admin.edit_link.${key}-label`);
-    
+
             return o;
         }, {});
         return opts;

--- a/js/src/forum/components/LinkItem.js
+++ b/js/src/forum/components/LinkItem.js
@@ -8,8 +8,9 @@ import icon from 'flarum/helpers/icon';
 export default class LinkItem extends LinkButton {
     view() {
         const link = this.attrs.link;
-        let className = `LinksButton ${this.attrs.className || 'Button Button--link'}`;
         const iconName = link.icon();
+        let className = `LinksButton ${this.attrs.className || 'Button Button--link'}`;
+        let rel = null;
 
         if (link.isInternal()) {
             const currentPath = m.route.get() || '/';
@@ -22,10 +23,20 @@ export default class LinkItem extends LinkButton {
             if (currentPath.indexOf(linkPath) === 0 && (currentPath === '/' || linkPath !== '/')) {
                 className += ' active';
             }
+        } else {
+            // Prevent security risk on older browsers.
+            // Modern browsers now have `noopener` by default and
+            // require `opener` to enable `window.opener`.
+            //
+            // Learn more:
+            // https://web.dev/external-anchors-use-rel-noopener
+            // https://mathiasbynens.github.io/rel-noopener/
+            rel = link.isNewtab() ? 'noopener noreferrer' : null;
         }
 
         const linkAttrs = {
-            className: className,
+            className,
+            rel,
             target: link.isNewtab() ? '_blank' : '',
             title: link.title(),
             external: !link.isInternal(),


### PR DESCRIPTION
Fixes #34

This PR prevent security risks on older browsers.

Modern browsers now provide `rel=noopener` behaviour by default, but [some older versions & IE](https://caniuse.com/mdn-html_elements_a_implicit_noopener), this behaviour is not present.

We also need `rel=noreferrer` for IE11 as that doesn't support `noopener`.

I don't think this should really ever be disabled as it's a pretty major security risk if a forum links to an unsafe site. It might be worth only supplying `noreferrer` on IE to benefit sites using analytics based on the `Referer` header.

Learn more:
- https://web.dev/external-anchors-use-rel-noopener
- https://mathiasbynens.github.io/rel-noopener/