### PR TITLE
Fix missing dropdown text on medium sizes

### DIFF
--- a/less/forum.less
+++ b/less/forum.less
@@ -86,6 +86,17 @@
   }
 }
 
+.Dropdown-menu {
+  .LinksButton-icon {
+    margin-top: 2px;
+    margin-right: 7px;
+  }
+
+  .LinksButton-title {
+    display: inline;
+  }
+}
+
 @media @phone {
   .SplitDropdown-button {
     width: calc(100% - 8.75px) !important;

--- a/less/forum.less
+++ b/less/forum.less
@@ -31,6 +31,15 @@
       color: @heading-color !important;
     }
 
+    &-icon {
+      margin-top: 2px;
+      margin-right: 7px;
+    }
+
+    &-title {
+      display: inline;
+    }
+
     &:hover,
     &:active,
     &:focus {
@@ -83,17 +92,6 @@
         display: none;
       }
     }
-  }
-}
-
-.Dropdown-menu {
-  .LinksButton-icon {
-    margin-top: 2px;
-    margin-right: 7px;
-  }
-
-  .LinksButton-title {
-    display: inline;
   }
 }
 


### PR DESCRIPTION
<!--
IMPORTANT: We LOVE seeing new pull requests, they excite us every single time they are submitted! As we have an obligation to maintain a healthy code standard, quality, and extensions, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

This fixes an issue where the text is missing on the dropdown on tablet breakpoints when the  "Show icons only on tablet screens" is toggled.
![CleanShot 2024-02-23 at 23 45 54@2x](https://github.com/FriendsOfFlarum/links/assets/1993075/1621f49a-5a1f-4c39-bbf4-b7f23fe0aa67)


**Changes proposed in this pull request:**
This PR update the CSS to show the button text on dropdown links.


**Screenshot**
Here's how the fix looks after.
![CleanShot 2024-02-23 at 23 45 22@2x](https://github.com/FriendsOfFlarum/links/assets/1993075/1b4b9768-e84c-43e3-9391-2bbe4d1bcb5b)

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [ ] ~~Backend changes: tests are green (run `composer test`)~~ No backend changes.

