### PR TITLE
[2.x] Fix down migration issue with prefix and add integration test

### DIFF
--- a/migrations/2021_01_17_000001_add_visibility_to_links_table.php
+++ b/migrations/2021_01_17_000001_add_visibility_to_links_table.php
@@ -13,7 +13,7 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Schema\Builder;
 
 return [
-    'up' => function (Builder $schema) {
+    'up' => static function (Builder $schema) {
         if ($schema->hasColumn('links', 'visibility')) {
             return;
         }
@@ -24,9 +24,15 @@ return [
         });
     },
 
-    'down' => function (Builder $schema) {
-        $schema->table('links', function (Blueprint $table) {
-            $table->dropIndex(['visibility']);
+    'down' => static function (Builder $schema) {
+        $indices = $schema->getIndexListing('links');
+
+        // A previous version of down migrations hardcoded the index name, which broke this when a prefix was in use.
+        // The ideal behavior is to let Laravel determine the index name, so we check in case the old hardcoded name exists.
+        $hasHardcodedIndex = in_array('links_visibility_index', $indices, true);
+
+        $schema->table('links', function (Blueprint $table) use ($hasHardcodedIndex) {
+            $table->dropIndex($hasHardcodedIndex ? 'links_visibility_index' : ['visibility']);
             $table->dropColumn('visibility');
         });
     },

--- a/migrations/2021_01_17_000001_drop_registered_users_only_column_and_migrate_options.php
+++ b/migrations/2021_01_17_000001_drop_registered_users_only_column_and_migrate_options.php
@@ -13,14 +13,14 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Schema\Builder;
 
 return [
-    'up' => function (Builder $schema) {
+    'up' => static function (Builder $schema) {
         $connection = $schema->getConnection();
-        $prefix = $connection->getTablePrefix();
-
-        // Use true instead of 1 for PostgreSQL compatibility (boolean type)
-        $connection->statement("UPDATE {$prefix}links SET visibility = 'members' WHERE registered_users_only = true");
 
         if ($schema->hasColumn('links', 'registered_users_only')) {
+            $connection->table('links')
+                ->where('registered_users_only', true)
+                ->update(['visibility' => 'members']);
+
             $schema->table('links', function (Blueprint $table) {
                 $table->dropIndex(['registered_users_only']);
                 $table->dropColumn('registered_users_only');

--- a/migrations/2024_10_11_000002_drop_visibility_from_links_table.php
+++ b/migrations/2024_10_11_000002_drop_visibility_from_links_table.php
@@ -39,7 +39,7 @@ return [
         if (!$schema->hasColumn('links', 'visibility')) {
             $schema->table('links', function (Blueprint $table) {
                 $table->enum('visibility', ['everyone', 'members', 'guests'])->default('everyone');
-                $table->index('visibility', 'links_visibility_index');
+                $table->index(['visibility']);
             });
         }
     },

--- a/tests/integration/db/MigrationsTest.php
+++ b/tests/integration/db/MigrationsTest.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of fof/links.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\Links\Tests\integration\db;
+
+use Flarum\Extension\ExtensionManager;
+use Flarum\Testing\integration\TestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+class MigrationsTest extends TestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->extension('fof-links');
+    }
+
+    #[Test]
+    public function it_rolls_back_migrations_without_errors(): void
+    {
+        // Boot the app so the extension is installed and migrated.
+        $this->app();
+
+        // Run down migrations for fof/reactions -- should not throw any exceptions.
+        $extensionManager = resolve(ExtensionManager::class);
+        $extensionManager->uninstall('fof-links');
+
+        // If no error occurred, the test will pass.
+        $this->addToAssertionCount(1);
+    }
+}

--- a/tests/phpunit.integration.xml
+++ b/tests/phpunit.integration.xml
@@ -1,25 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/12.5/phpunit.xsd"
     backupGlobals="false"
-    backupStaticAttributes="false"
+    backupStaticProperties="false"
     colors="true"
-    convertErrorsToExceptions="true"
-    convertNoticesToExceptions="true"
-    convertWarningsToExceptions="true"
     processIsolation="true"
     stopOnFailure="false"
 >
-    <coverage processUncoveredFiles="true">
+    <testsuites>
+          <testsuite name="Flarum Integration Tests">
+            <directory suffix="Test.php">./integration</directory>
+            <exclude>./integration/tmp</exclude>
+        </testsuite>
+    </testsuites>
+    <source
+      ignoreIndirectDeprecations="true">
         <include>
             <directory suffix=".php">../src/</directory>
         </include>
-    </coverage>
-    <testsuites>
-        <testsuite name="Flarum Integration Tests">
-            <directory suffix="Test.php">./integration</directory>
-             <exclude>./integration/tmp</exclude>
-        </testsuite>
-    </testsuites>
+    </source>
 </phpunit>


### PR DESCRIPTION

<!--
IMPORTANT: We LOVE seeing new pull requests, they excite us every single time they are submitted! As we have an obligation to maintain a healthy code standard, quality, and extensions, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #78**

**Changes proposed in this pull request:**
- Add integration test for down migrations
- Change the `->statement()` query into query builder to avoid DB engine issues; move it within the `if` check for column existence 
- Fix `visibility` index in down migration having hardcoded name, and then being dropped without hardcoding -- broke prefixes. Switched to no hardcoding, but still supporting state where it was

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**Confirmed**

- ~~Frontend changes: tested on a local Flarum installation.~~
- [x] Backend changes: tests are green (run `composer test`).
