### PR TITLE
[2.x] fix: label link icon spacing and dropdown item alignment

### DIFF
--- a/js/src/forum/components/LinkItem.tsx
+++ b/js/src/forum/components/LinkItem.tsx
@@ -30,27 +30,35 @@ export default class LinkItem extends LinkButton {
 
   labelView(vnode: Mithril.Vnode<ILinkItemAttrs, never>): JSX.Element {
     const link = this.attrs.link;
+    const title = <span className="LinksButton-title">{link.title()}</span>;
 
-    const LinkLabelNode = this.attrs.inDropdown ? 'span' : Button;
-
-    return (
-      <>
-        {this.attrs.inDropdown && <Separator />}
-        <LinkLabelNode
-          class={classList(this.class, 'LinksButton--label')}
-          onclick={(e: MouseEvent) => {
-            if (this.attrs.inDropdown) {
+    if (this.attrs.inDropdown) {
+      return (
+        <>
+          <Separator />
+          <span
+            class={classList(this.class, 'LinksButton--label')}
+            onclick={(e: MouseEvent) => {
               // don't close dropdown when clicking label
               e.stopPropagation();
-            }
-          }}
-          data-toggle={this.attrs.isDropdownButton ? 'dropdown' : undefined}
-        >
-          {this.icon}
-          <span className="LinksButton-title">{link.title()}</span>
-        </LinkLabelNode>
-        {this.attrs.inDropdown && <Separator />}
-      </>
+            }}
+          >
+            {this.icon}
+            {title}
+          </span>
+          <Separator />
+        </>
+      );
+    }
+
+    // Pass the icon to Button as an attr rather than a child: children are
+    // wrapped in .Button-labelText, one level below where the button's flex
+    // gap separates icon from label, so an icon passed as a child sits flush
+    // against the title.
+    return (
+      <Button class={classList(this.class, 'LinksButton--label')} icon={this.icon} data-toggle={this.attrs.isDropdownButton ? 'dropdown' : undefined}>
+        {title}
+      </Button>
     );
   }
 

--- a/less/forum.less
+++ b/less/forum.less
@@ -25,6 +25,12 @@
   .LinksButton {
     color: var(--button-color, var(--control-color)) !important;
 
+    // These keep their Button classes inside the menu, and .Button centers
+    // its content — core's own menu items carry no Button class, so they
+    // left-align by default. Only visible when an item is shorter than the
+    // menu, which is why link dropdowns looked fine and label ones didn't.
+    justify-content: flex-start;
+
     &--label {
       color: var(--heading-color) !important;
     }


### PR DESCRIPTION
Two display bugs on label-type links (links with no URL), both root-caused against core's button rendering.

## 1. Icon flush against the title

| | |
|---|---|
| Discuss / Google (URL links) | icon → 7px gap → title |
| **Legal (label link)** | **icon → 0px → title** |

Label links rendered core `Button` with the icon passed as a **child**, and `Button` wraps all children in `.Button-label > .Button-labelText` — one level below where the button's `gap: 7px` flex spacing operates. URL links render through `LinkButton`, which keeps icon and title as direct children, hence the inconsistency.

Fix: pass the icon to `Button` via its `icon` attr, the way every other Flarum button renders one. The in-dropdown `span` variant is unchanged; the label view now branches explicitly instead of sharing one node type.

Measured live before → after: label button `gap 0px, icon nested in Button-labelText` → `gap 7px, icon direct child` — identical measurements to the URL links either side of it.

## 2. Dropdown items centered instead of left-aligned

Items inside link dropdowns keep their `Button Button--link` classes, and `.Button { justify-content: center }` centers their content. Core's own menu items carry **no** Button class (verified: computed `justify-content: normal` on core's sort dropdown), so they left-align by default.

The centering only shows when an item is narrower than the menu — which is why the dropdown under a URL link (whose item happened to fill the 160px row) looked correct while the dropdown under a label didn't. Same computed styles on both; the difference was content width, not the dropdown type.

Fix: `justify-content: flex-start` on `.LinksButton` within `.LinkDropdown ul` — covers regular in-dropdown items and the split-dropdown button copies that become visible menu items on mobile.

Verified live: menu item now computes `flex-start` with content at the menu's standard 15px padding, matching core dropdowns.

## Verification

- Both fixes measured in-browser before/after (DOM structure, computed styles, pixel gaps) and screenshotted
- Dropdown toggle, label non-navigation, and separators behave as before
- webpack builds clean; Prettier applied; the repo's pre-existing fresh-clone typings errors are unchanged (identical on a stashed baseline)