### PR TITLE
[2.x] fix: improve a11y of link dropdown

### DIFF
--- a/js/src/forum/components/LinkDropdown.js
+++ b/js/src/forum/components/LinkDropdown.js
@@ -31,7 +31,12 @@ export default class LinkDropdown extends SplitDropdown {
 
     return [
       firstChild,
-      <button className={classList('Dropdown-toggle', 'Button', 'Button--icon', this.attrs.buttonClassName)} aria-haspopup="menu" ariaLabel={app.translator.trans('fof-links.forum.header.toggle_dropdown_accessible_label')} data-toggle="dropdown">
+      <button
+        className={classList('Dropdown-toggle', 'Button', 'Button--icon', this.attrs.buttonClassName)}
+        aria-haspopup="menu"
+        ariaLabel={app.translator.trans('fof-links.forum.header.toggle_dropdown_accessible_label')}
+        data-toggle="dropdown"
+      >
         <Icon name="fas fa-caret-down" className="Button-caret" />
       </button>,
     ];

--- a/js/src/forum/components/LinkDropdown.js
+++ b/js/src/forum/components/LinkDropdown.js
@@ -31,7 +31,7 @@ export default class LinkDropdown extends SplitDropdown {
 
     return [
       firstChild,
-      <button className={classList('Dropdown-toggle', 'Button', 'Button--icon', this.attrs.buttonClassName)} data-toggle="dropdown">
+      <button className={classList('Dropdown-toggle', 'Button', 'Button--icon', this.attrs.buttonClassName)} aria-haspopup="menu" aria-label={app.translator.trans('fof-links.forum.header.toggle_dropdown_accessible_label')} data-toggle="dropdown">
         <Icon name="fas fa-caret-down" className="Button-caret" />
       </button>,
     ];

--- a/js/src/forum/components/LinkDropdown.js
+++ b/js/src/forum/components/LinkDropdown.js
@@ -31,7 +31,7 @@ export default class LinkDropdown extends SplitDropdown {
 
     return [
       firstChild,
-      <button className={classList('Dropdown-toggle', 'Button', 'Button--icon', this.attrs.buttonClassName)} aria-haspopup="menu" aria-label={app.translator.trans('fof-links.forum.header.toggle_dropdown_accessible_label')} data-toggle="dropdown">
+      <button className={classList('Dropdown-toggle', 'Button', 'Button--icon', this.attrs.buttonClassName)} aria-haspopup="menu" ariaLabel={app.translator.trans('fof-links.forum.header.toggle_dropdown_accessible_label')} data-toggle="dropdown">
         <Icon name="fas fa-caret-down" className="Button-caret" />
       </button>,
     ];

--- a/locale/en.yml
+++ b/locale/en.yml
@@ -41,6 +41,13 @@ fof-links:
     settings:
       show_icons_only_on_tablet: Show icons only on tablet screens
 
+  # Translations in this namespace are used by the forum user interface.
+  forum:
+  
+    # These translations are used in the header menu.
+    header:
+      toggle_dropdown_accessible_label: Toggle link dropdown menu
+      
   # Strings in this namespace are referenced by two or more unique keys.
   ref:
     create_link: Create Link


### PR DESCRIPTION
**Changes proposed in this pull request:**
Add aria labels and popup menu attribute to ensure accessibility of the dropdown menu for link items with sub-items.

**Reviewers should focus on:**
Correct use of app.translator.trans(...) :P

**Confirmed**

- [X] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).